### PR TITLE
Set up GitHub Pages deployment

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -1,1 +1,0 @@
-DirectoryIndex index.html index.php index.htm parking-page.html parking-page.shtml

--- a/.htaccess.ncbak
+++ b/.htaccess.ncbak
@@ -1,1 +1,0 @@
-DirectoryIndex index.html index.php index.htm parking-page.html

--- a/404.html
+++ b/404.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>Page Not Found</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <link rel="stylesheet" href="css/style.css" />
+  <link rel="shortcut icon" type="image/png" href="favicon.png"/>
+</head>
+<body>
+  <main>
+    <h1>404 - Page Not Found</h1>
+    <p>The page you are looking for does not exist.</p>
+    <p><a href="index.html">Return to the homepage</a></p>
+  </main>
+</body>
+</html>

--- a/CNAME
+++ b/CNAME
@@ -1,0 +1,1 @@
+example.com

--- a/README.md
+++ b/README.md
@@ -1,0 +1,17 @@
+# Levantine
+
+This repository contains the static site for **Levantine**. It is ready to be published using GitHub Pages.
+
+## Deployment
+
+1. Fork or clone this repository.
+2. Push the `main` branch to GitHub.
+3. In the repository settings on GitHub, enable **Pages** and select the `main` branch with the root folder.
+4. Commit customizations such as the [`CNAME`](CNAME) file with your domain name if you use a custom domain.
+5. Visit `https://<username>.github.io/Levantine/` or your custom domain after the build completes.
+
+A [`404.html`](404.html) page is included for handling not‑found errors.
+
+## Local development
+
+This is a static site. Open `index.html` in a web browser to preview. No build step is required.


### PR DESCRIPTION
## Summary
- remove legacy .htaccess files
- add 404 page and placeholder CNAME for GitHub Pages
- document deployment steps

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68b1a458ed3c832eb985e7d071881099